### PR TITLE
chore(config): use 5000 as default port

### DIFF
--- a/src/ReasonWebServer.re
+++ b/src/ReasonWebServer.re
@@ -2,7 +2,7 @@
 open Lwt.Infix;
 
 let defaultAddress = "0.0.0.0";
-let defaultPort = 80;
+let defaultPort = 5000;
 
 let make_request_handler: (
     ~uri: Uri.t,


### PR DESCRIPTION
Ports below 1024 cannot be bound by normal users on UNIX systems.